### PR TITLE
In appveyor: specify the project name

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,8 @@ environment:
 cache:
   - C:\ADL_tools\
 
+clone_folder: C:\projects\embedded-runtimes
+
 install:
   # Define environment variables
   - ps: $env:TOOLS_DIR = "C:\ADL_tools\"


### PR DESCRIPTION
This is needed by the appveyor script to execute the runtime installation.